### PR TITLE
Node import prefixes removal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sourcemeter",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sourcemeter",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sourcemeter",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Query information from a running Source Dedicated Server (SRCDS) using UDP/IP packets.",
   "keywords": [
     "A2S_INFO",

--- a/src/infoQuery/decodeInfoQuery/decodeInfoQuery.ts
+++ b/src/infoQuery/decodeInfoQuery/decodeInfoQuery.ts
@@ -2,7 +2,7 @@ import type {
   InfoResultNonPredicated,
   InfoResultPredicated,
 } from './infoResults'
-import { Buffer } from 'node:buffer'
+import { Buffer } from 'buffer'
 import {
   nonPredicated as intentsNonPredicated,
   predicated as intentsPredicated,

--- a/src/infoQuery/decodeInfoQuery/decoderIntents/DecoderIntent.ts
+++ b/src/infoQuery/decodeInfoQuery/decoderIntents/DecoderIntent.ts
@@ -1,4 +1,4 @@
-import type { Buffer } from 'node:buffer'
+import type { Buffer } from 'buffer'
 import type { DecodedDataTypes } from '../../../transcoder'
 
 export type DecoderIntent<Name> = {

--- a/src/infoQuery/decodeInfoQuery/infoResults/InfoResultDecoded.ts
+++ b/src/infoQuery/decodeInfoQuery/infoResults/InfoResultDecoded.ts
@@ -1,3 +1,3 @@
-import type { Buffer } from 'node:buffer'
+import type { Buffer } from 'buffer'
 
 export type InfoResultDecoded<T> = T & { remaining: Buffer }

--- a/src/infoQuery/sendInfoQueries.ts
+++ b/src/infoQuery/sendInfoQueries.ts
@@ -1,7 +1,7 @@
 import type { Encoded } from '../transcoder'
 import type { InfoResultInitial } from './decodeInfoQuery'
 import type { Query, RemoteDestination } from '../query'
-import { Buffer } from 'node:buffer'
+import { Buffer } from 'buffer'
 import { encodeCharacter, encodeLong, encodeString } from '../transcoder'
 import {
   decodeInfoQueryInitial,

--- a/src/query/createUDPSocket.ts
+++ b/src/query/createUDPSocket.ts
@@ -1,6 +1,6 @@
-import type { Socket } from 'node:dgram'
-import { createSocket } from 'node:dgram'
-import { Buffer } from 'node:buffer'
+import type { Socket } from 'dgram'
+import { createSocket } from 'dgram'
+import { Buffer } from 'buffer'
 import handleUDPSocketError from './handleUDPSocketError'
 
 export type RemoteDestination = {

--- a/src/query/handleUDPSocketError.ts
+++ b/src/query/handleUDPSocketError.ts
@@ -1,4 +1,4 @@
-import type { Socket } from 'node:dgram'
+import type { Socket } from 'dgram'
 
 export default function handleUDPSocketError({
   reject,

--- a/src/query/query.ts
+++ b/src/query/query.ts
@@ -1,6 +1,6 @@
-import type { Socket } from 'node:dgram'
+import type { Socket } from 'dgram'
 import type { RemoteInfo } from './createUDPSocket'
-import { Buffer } from 'node:buffer'
+import { Buffer } from 'buffer'
 import { createUDPSocket } from './createUDPSocket'
 import durationTimer from './durationTimer'
 import handleUDPSocketError from './handleUDPSocketError'

--- a/src/transcoder/decoder.ts
+++ b/src/transcoder/decoder.ts
@@ -1,4 +1,4 @@
-import type { Buffer } from 'node:buffer'
+import type { Buffer } from 'buffer'
 
 type DecodedDataType<Value> = { remaining: Buffer; value: Value }
 

--- a/src/transcoder/encoder.ts
+++ b/src/transcoder/encoder.ts
@@ -1,4 +1,4 @@
-import { Buffer } from 'node:buffer'
+import { Buffer } from 'buffer'
 
 export type Encoded = { buffer: Buffer; size: number }
 


### PR DESCRIPTION
Fixes Vercel default incompatibility with [contemporary Node imports](https://nodejs.org/api/esm.html#node-imports).